### PR TITLE
remove the '>' symbol that breaks riboviz from the example metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ provenance:
   GEO: GSExxxxxxx # gene expression omnibus references for dataset, if relevant
   reference: Genome-Wide Analysis in Vivo of Translation with Nucleotide Resolution Using Ribosome Profiling, Ingolia et al 2009
   DOI: 10.1126/science.1168978
-  notes: >
-    Re-analysis of data from Ingolia 2009 to an updated yeast transcriptome.
+  notes:  Re-analysis of data from Ingolia 2009 to an updated yeast transcriptome.
 ```
 
 We are currently (May 2020) reviewing the format of this in issue [#riboviz166](https://github.com/riboviz/riboviz/issues/166), so the format may change.


### PR DESCRIPTION
This should close riboviz issue [riboviz/#166](https://github.com/riboviz/riboviz/issues/166). 

Removed a '>' symbol from the metadata section which was found to break riboviz, but wasn't removed from this documentation previously. 

Otherwise, no other changes on this PR. 