### PR TITLE
Cryptococcus error 109

### DIFF
--- a/fungi/cryptococcus/Wallace_2020_H99_4-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
+++ b/fungi/cryptococcus/Wallace_2020_H99_4-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
@@ -47,7 +47,7 @@ max_read_length: 50 # Maximum read length in H5 output
 min_read_length: 10 # Minimum read length in H5 output
 multiplex_fq_files: NULL # Multiplexed fastq files to be processed, relative to dir_in
 num_processes: 2 # Number of processes to parallelize over
-orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/H99_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
+orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/modified_H99_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
 orf_gff_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/H99_10p_up12dwn9_CDS_120bpL_120bpR.gff3 # GFF2/GFF3 file for ORFs
 orf_index_prefix: H99_CDS_with_120bputrs # ORF index file prefix, relative to dir_index
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)

--- a/fungi/cryptococcus/Wallace_2020_JEC21_2-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
+++ b/fungi/cryptococcus/Wallace_2020_JEC21_2-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
@@ -45,7 +45,7 @@ max_read_length: 50 # Maximum read length in H5 output
 min_read_length: 10 # Minimum read length in H5 output
 multiplex_fq_files: NULL # Multiplexed fastq files to be processed, relative to dir_in
 num_processes: 16 # Number of processes to parallelize over
-orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/modified_JEC21_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
+orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/JEC21_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
 orf_gff_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/JEC21_10p_up12dwn9_CDS_120bpL_120bpR.gff3 # GFF2/GFF3 file for ORFs
 orf_index_prefix: JEC21_CDS_with_120bputrs # ORF index file prefix, relative to dir_index
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)

--- a/fungi/cryptococcus/Wallace_2020_JEC21_2-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
+++ b/fungi/cryptococcus/Wallace_2020_JEC21_2-samples_10p_up12dwn9_CDS_120bpL_120bpR_config.yaml
@@ -45,7 +45,7 @@ max_read_length: 50 # Maximum read length in H5 output
 min_read_length: 10 # Minimum read length in H5 output
 multiplex_fq_files: NULL # Multiplexed fastq files to be processed, relative to dir_in
 num_processes: 16 # Number of processes to parallelize over
-orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/JEC21_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
+orf_fasta_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/modified_JEC21_10p_up12dwn9_CDS_with_120bputrs.fa # ORF file to align to
 orf_gff_file: ../../riboviz/example-datasets/fungi/cryptococcus/annotation/JEC21_10p_up12dwn9_CDS_120bpL_120bpR.gff3 # GFF2/GFF3 file for ORFs
 orf_index_prefix: JEC21_CDS_with_120bputrs # ORF index file prefix, relative to dir_index
 primary_id: Name # Primary gene IDs to access the data (YAL001C, YAL003W, etc.)


### PR DESCRIPTION
Branch created for solving issue #109 
'FlankCDS' regions deleted using command `sed 's/ FlankCDS//g' $filename > modified$filename` from both fasta files in `fungi/cryptococcus/annotation/H99_10p_up12dwn9_CDS_with_120bputrs.fa` and `fungi/cryptococcus/annotation/JEC21_10p_up12dwn9_CDS_with_120bputrs.fa`

Both H99 and JEC21 datasets were fully run in riboviz afterwards and finished successfully.